### PR TITLE
Fix generate_code.cmd when plugin path has spaces

### DIFF
--- a/Tools/generate_code.cmd
+++ b/Tools/generate_code.cmd
@@ -41,8 +41,8 @@ if not exist %CPP_OUTPUT_PATH% mkdir %CPP_OUTPUT_PATH%
  %INPUT_PROTO_FILE%
 
 :: fix protobuf compile warning 
-call :FixCompileWarning %FIX_PROTO_H% %CPP_OUTPUT_PATH%\%INPUT_PROTO_FILE% "pb.h"
-call :FixCompileWarning %FIX_PROTO_CPP% %CPP_OUTPUT_PATH%\%INPUT_PROTO_FILE% "pb.cc"
+call :FixCompileWarning "%FIX_PROTO_H%" %CPP_OUTPUT_PATH%\%INPUT_PROTO_FILE% "pb.h"
+call :FixCompileWarning "%FIX_PROTO_CPP%" %CPP_OUTPUT_PATH%\%INPUT_PROTO_FILE% "pb.cc"
 goto :eof
 
 :FixCompileWarning


### PR DESCRIPTION
When the `fix_proto_h.txt` and `fix_proto_cpp.txt` files are in a path that contains spaces, the `generate_code.cmd` script does not work correctly. This MR fixes the issue for this particular case.