### PR TITLE
Bug Fix - Destroy race condition

### DIFF
--- a/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager.cpp
+++ b/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager.cpp
@@ -13,6 +13,11 @@ UTurboLinkGrpcManager::UTurboLinkGrpcManager()
 
 UTurboLinkGrpcManager::~UTurboLinkGrpcManager()
 {
+	for (auto& CurrentService : WorkingService)
+	{
+		CurrentService.Value->Shutdown();
+	}
+
 	delete d;
 }
 


### PR DESCRIPTION
# Issue
When shutting down, it's possible that some services have outgoing operations. This race condition prominent in PIE when an async gRPC is called right before the PIE is being exited causing the Editor to crash.

# Solution
On destroy of the GrpcManager, shutdown all working services.